### PR TITLE
Add priority flag to header image

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -40,7 +40,7 @@ const t = useTranslations(lang)
       class="invert-0 dark:invert"
       width={517}
       height={299}
-      loading="eager"
+      priority
     />
   </header>
 </a>


### PR DESCRIPTION
Latest astro version added a `priority` flag. This uses it now on the header image.