### PR TITLE
gh-actions: Schedule build and deploy after every Thursday meeting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
+  # Run after our weekly meeting
+  schedule:
+  - cron: "13 23 * * 4"
 
 # Allow this job to clone the repo and create a page deployment
 permissions:


### PR DESCRIPTION
This addition should cause the workflow "Deploy to Website" to trigger every Friday at 00:13 or 01:13 German time (see [docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule)). This should ensure the info regarding the next meeting is always up to date.

Closes #131