### PR TITLE
iCal generation: fall back on fs timestamps if git timestamps are not available

### DIFF
--- a/src/remark-created-time.mjs
+++ b/src/remark-created-time.mjs
@@ -1,11 +1,11 @@
-import { execSync } from "child_process"
+import { execSync } from "child_process";
+import { statSync } from "fs";
 
 export function remarkCreatedTime() {
   return function (tree, file) {
-    const filepath = file.history[0]
-    const result = execSync(
-      `git log --pretty="format:%cI" "${filepath}" | tail -1`,
-    )
-    file.data.astro.frontmatter.created = result.toString()
+    const filepath = file.history[0];
+    const gitresult = execSync(`git log --pretty="format:%cI" "${filepath}" | tail -1`).toString();
+    const fsresult = statSync(filepath).birthtime.toISOString();
+    file.data.astro.frontmatter.created = gitresult ? gitresult : fsresult;
   }
 }

--- a/src/remark-modified-time.mjs
+++ b/src/remark-modified-time.mjs
@@ -1,9 +1,11 @@
-import { execSync } from "child_process"
+import { execSync } from "child_process";
+import { statSync } from "fs";
 
 export function remarkModifiedTime() {
   return function (tree, file) {
-    const filepath = file.history[0]
-    const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`)
-    file.data.astro.frontmatter.lastModified = result.toString()
+    const filepath = file.history[0];
+    const gitresult = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`).toString();
+    const fsresult = statSync(filepath).mtime.toISOString();
+    file.data.astro.frontmatter.lastModified = gitresult ? gitresult : fsresult;
   }
 }


### PR DESCRIPTION
I ran into an issue where the build would fail if the git log is missing for an event (for example when events are added but not yet committed):

![/de/calendar.ics `stamp` has to be a valid date!](https://github.com/user-attachments/assets/3ec80578-d28b-4522-8f81-2c2bd3a76f74)

I've changed the remark plugins to fall back on file system timestamps.