### PR TITLE
Check end time instead of day  when computing next treff

### DIFF
--- a/src/chaostreff.ts
+++ b/src/chaostreff.ts
@@ -101,5 +101,5 @@ const createTreffsList = () => {
 }
 
 export const nextTreff = createTreffsList()
-  .filter((treff) => isAfter(treff.start, startOfDay(new Date())))
+  .filter((treff) => isAfter(treff.end, new Date()))
   .toSorted((a, b) => a.start.getTime() - b.start.getTime())[0]


### PR DESCRIPTION
As pointed out by @razzeee , the scheduled build and deploy #131 doesn't appear to work correctly.
I believe this is because the action runs at 23hrs UTC (see logs) and the code used to check if the regular meeting has happened already only compared the day instead of time.