### PR TITLE
fix: correctly handle fs stats fallback for untracked files

### DIFF
--- a/src/remark-created-time.mjs
+++ b/src/remark-created-time.mjs
@@ -4,8 +4,8 @@ import { statSync } from "fs";
 export function remarkCreatedTime() {
   return function (tree, file) {
     const filepath = file.history[0];
-    const gitresult = execSync(`git log --pretty="format:%cI" "${filepath}" | tail -1`).toString();
+    const gitresult = execSync(`git log --pretty="format:%cI" "${filepath}" | tail -1`).toString().trim();
     const fsresult = statSync(filepath).birthtime.toISOString();
-    file.data.astro.frontmatter.created = gitresult ?? fsresult;
+    file.data.astro.frontmatter.created = gitresult || fsresult;
   }
 }

--- a/src/remark-modified-time.mjs
+++ b/src/remark-modified-time.mjs
@@ -4,8 +4,8 @@ import { statSync } from "fs";
 export function remarkModifiedTime() {
   return function (tree, file) {
     const filepath = file.history[0];
-    const gitresult = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`).toString();
+    const gitresult = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`).toString().trim();
     const fsresult = statSync(filepath).mtime.toISOString();
-    file.data.astro.frontmatter.lastModified = gitresult ?? fsresult;
+    file.data.astro.frontmatter.lastModified = gitresult || fsresult;
   }
 }


### PR DESCRIPTION
The coalescing operator does not work as intended here.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing

It returns the right hand side only when the left hand side is null or undefined. But git log returns an empty string on untracked files, hence an empty string is used instead of an iso date time string and the build fails.

The logical or is the correct approach here since "" will evaluate to false.